### PR TITLE
Allow the postcode submit button text to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ The following keys are expected to be defined in your translations file.
 * `fields.{key}-postcode.label` - Label for the postcode field when shown on the lookup and manual steps. Defaults to `'Postcode'`
 * `pages.address-lookup.postcode-api.not-found` - Message to show if postcode not found. Defaults to `'Sorry – we couldn’t find any addresses for that postcode, enter your address manually'`
 * `pages.address-lookup.postcode-api.cant-connect` - Message to show if unable to connect to the lookup service. Defaults to `'Sorry – we couldn’t connect to the postcode lookup service at this time, enter your address manually'`
+* `pages.address-lookup.find-address` - Postcode submit button text. Defaults to 'Find address'

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,6 +3,7 @@
 'use strict';
 
 module.exports = {
+  FIND_ADDRESS: 'Find address',
   CANT_FIND: 'I can\'t find the address in the list',
   CHANGE: 'Change',
   POSTCODE_LABEL: 'Postcode',

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,6 +135,8 @@ module.exports = config => {
       const section = this.options.route.replace(/^\//, '');
       const editLink = conditionalTranslate('pages.address-lookup.edit', req.translate) || defaults.CHANGE;
       const cantFind = conditionalTranslate('pages.address-lookup.cantfind', req.translate) || defaults.CANT_FIND;
+      const findAddress = conditionalTranslate('pages.address-lookup.find-address', req.translate) ||
+        defaults.FIND_ADDRESS;
 
       let postcodeApiMessageKey;
       let postcodeError;
@@ -155,6 +157,7 @@ module.exports = config => {
         enterManually: conditionalTranslate('pages.address.lookup.enter-manually', req.translate) ||
           defaults.ENTER_MANUALLY,
         route: this.options.route,
+        findAddress,
         editLink,
         cantFind,
         postcodeError,

--- a/templates/postcode.html
+++ b/templates/postcode.html
@@ -4,6 +4,6 @@
       {{#renderField}}{{/renderField}}
     {{/fields}}
     <p><span class="link"><a href="{{#qs}}step=manual{{/qs}}">{{enterManually}}</a></span></p>
-    {{#input-submit}}continue{{/input-submit}}
+    {{#input-submit}}{{findAddress}}{{/input-submit}}
   {{/page-content}}
 {{/partials-page}}


### PR DESCRIPTION
- override the postcode submit button text at `pages.address-lookup.find-address`