### PR TITLE
Use config port for mock api calls in functional tests

### DIFF
--- a/test/functional/apps/default.js
+++ b/test/functional/apps/default.js
@@ -2,13 +2,13 @@
 
 const AddressLookup = require('../../../');
 
-module.exports = {
+module.exports = config => ({
   steps: {
     '/one': {
       behaviours: AddressLookup({
         addressKey: 'address-one',
         apiSettings: {
-          hostname: 'http://localhost:8081/api/postcode-test'
+          hostname: `http://localhost:${config.port}/api/postcode-test`
         },
         validate: {
           allowedCountries: ['England']
@@ -18,4 +18,4 @@ module.exports = {
     },
     '/two': {}
   }
-};
+});

--- a/test/functional/apps/required.js
+++ b/test/functional/apps/required.js
@@ -2,14 +2,14 @@
 
 const AddressLookup = require('../../../');
 
-module.exports = {
+module.exports = config => ({
   steps: {
     '/one': {
       behaviours: AddressLookup({
         addressKey: 'address-one',
         required: true,
         apiSettings: {
-          hostname: 'http://localhost:8081/api/postcode-test'
+          hostname: `http://localhost:${config.port}/api/postcode-test`
         },
         validate: {
           allowedCountries: ['England']
@@ -19,4 +19,4 @@ module.exports = {
     },
     '/two': {}
   }
-};
+});

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -19,7 +19,7 @@ describe('Functional tests', () => {
   describe('default behaviour', () => {
 
     before(() => {
-      app = App(require('./apps/default')).listen(config.port);
+      app = App(require('./apps/default')(config)).listen(config.port);
     });
 
     after(() => {
@@ -134,7 +134,7 @@ describe('Functional tests', () => {
   describe('required', () => {
 
     before(() => {
-      app = App(require('./apps/required')).listen(config.port);
+      app = App(require('./apps/required')(config)).listen(config.port);
     });
 
     after(() => {


### PR DESCRIPTION
The port is configurable in some places, but the port used for address lookup api calls isn't using the same config, so it can't actually be configured without failing.

Instead use the configured port everywhere so that cahnges to config are respected and the tests run correctly irrespective of the port configuration.