### PR TITLE
Prevent unsetting address on manual entry step

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,6 @@ module.exports = config => {
     getValues(req, res, callback) {
       if (req.query.step === 'manual') {
         req.sessionModel.unset([
-          addressKey,
           `${addressKey}-postcodeApiMeta`
         ]);
       } else if (req.query.step === 'lookup') {

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -130,6 +130,20 @@ describe('Functional tests', () => {
         })
     );
 
+    it('persists address on manual entry step when returning from later step (bugfix)', () =>
+      browser.url('/one')
+        .$('a[href*="step=manual"]')
+        .click()
+        .$('textarea')
+        .setValue('1 High Street')
+        .submitForm('form')
+        .back()
+        .getValue('textarea')
+        .then(text => {
+          assert.equal(text, '1 High Street');
+        })
+    );
+
   });
 
   describe('required', () => {

--- a/test/functional/lib/browser.js
+++ b/test/functional/lib/browser.js
@@ -2,6 +2,7 @@
 
 const webdriverio = require('webdriverio');
 const options = {
+  deprecationWarnings: false,
   desiredCapabilities: {
     browserName: 'chrome'
   }


### PR DESCRIPTION
The manual entry step was explicitly deleting its value on GET. It wasn't obvious why this was the case, but I can't think of any good reason for it.

Removing the unset means data is correctly persisted when returning to the address step from a later step.