### PR TITLE
SD-74: Fix broken validation for manual address page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-behaviour-address-lookup",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A HOF Behaviour for a multi-step postcode lookup",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Jira Ticket**: https://collaboration.homeoffice.gov.uk/jira/browse/SD-74

**Changes**: Address changes to OriginalURL in getErrorStep, causing "undefined" errors when checking validation in the manual address fork of end-tenancy.