### PR TITLE
SD-74: Removed the getErrorStep to fix and error with the manual address validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ jspm_packages
 .node_repl_history
 
 package-lock.json
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,10 +211,6 @@ module.exports = config => {
       return super.saveValues(req, res, callback);
     }
 
-    getErrorStep(err, req) {
-      return `${super.getErrorStep(err, req)}?${querystring.stringify(req.query)}`;
-    }
-
     // eslint-disable-next-line consistent-return
     validate(req, res, callback) {
       if (req.query.step === 'postcode' && this.model.get('validate')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-behaviour-address-lookup",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A HOF Behaviour for a multi-step postcode lookup",
   "main": "index.js",
   "scripts": {

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -56,7 +56,6 @@ describe('Functional tests', () => {
         .submitForm('form')
         .getUrl()
         .then(url => {
-          assert.ok(url.includes('step=postcode'));
           assert.ok(url.includes('/one'));
         })
     );
@@ -68,7 +67,6 @@ describe('Functional tests', () => {
         .submitForm('form')
         .getUrl()
         .then(url => {
-          assert.ok(url.includes('step=postcode'));
           assert.ok(url.includes('/one'));
         })
     );
@@ -99,7 +97,6 @@ describe('Functional tests', () => {
         .click()
         .getUrl()
         .then(url => {
-          assert.ok(url.includes('step=postcode'));
           assert.ok(url.includes('/one'));
         })
     );


### PR DESCRIPTION
**Jira Ticket**: https://collaboration.homeoffice.gov.uk/jira/browse/SD-74

**Changes**: 

- Removed the getErrorStep to fix and error with the manual address step validation. (URL was concatenating to work around bug found in HOF version 13, bug was fixed in HOF version 14+, so this work around is no longer needed).
- Changed the tests for validation error, as these were allowing for the concatenated URL.
- Updated version to 2.2.2.
